### PR TITLE
refactor(rankings): mimic the look of in game track selector

### DIFF
--- a/app/rankings/page.css
+++ b/app/rankings/page.css
@@ -1,0 +1,33 @@
+.cup-list {
+  max-width: 1024px;
+  
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+
+  justify-items: center;
+  justify-content: center;
+
+  @media (min-width: 1024px) {
+    display: grid;
+    grid-template-columns: repeat(6, minmax(0, 1fr));
+  }
+}
+
+.track-list {
+  max-width: 1280px;
+
+  display: grid;
+  gap: 1rem;
+
+  justify-items: center;
+  justify-content: center;
+
+  @media (min-width: 640px) {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  @media (min-width: 1280px) {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+}

--- a/app/rankings/page.tsx
+++ b/app/rankings/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import './page.css'
 import Image from "next/image";
 import TrackList from "@/helpers/types/TrackList";
 import { useState } from "react";
@@ -7,7 +8,6 @@ import { Card } from "react-bootstrap";
 import Link from "next/link";
 
 export default function RankingsPage() {
-
     const [currentCup, setCurrentCup] = useState<number>(0);
 
     return (
@@ -15,7 +15,7 @@ export default function RankingsPage() {
             <form className="text-center w-100 p-4 bg-light shadow-lg">
                 <h1 className="mb-3">Rankings</h1>
                 <h6>Select a cup</h6>
-                <div className="d-flex flex-wrap justify-content-around btn-group">
+                <div className="cup-list mx-auto w-100">
                     {TrackList.map((cup, cupIdx) => {
                         return (
                             <button
@@ -32,7 +32,7 @@ export default function RankingsPage() {
                     })}
                 </div>
                 <hr />
-                <div className="d-flex flex-column justify-content-between align-items-center">
+                <div className="track-list mx-auto w-100">
                     {TrackList[currentCup].tracks.map((track) => {
                         return (
                             <Link href={`/rankings/${track.id}`} passHref key={track.internalName} style={{ textDecoration: "none" }}>


### PR DESCRIPTION
This PR refactors the ranking page to make it look similar to how the in-game cup / track selector looks like.

Note that I've created an external CSS file since Bootstrap / Bootstrap React is too restrictive and doesn't acommodate the needs of the refactored UI.

I'd figured, this would be a QoL change to the site :D

https://github.com/PretendoNetwork/mario_kart_8_website/assets/2129163/2a50b7c4-456d-4bd6-ab94-f6c602dd008c

